### PR TITLE
KB-12828: Designation search enhancement

### DIFF
--- a/src/main/java/com/igot/cb/pores/elasticsearch/service/EsUtilServiceImpl.java
+++ b/src/main/java/com/igot/cb/pores/elasticsearch/service/EsUtilServiceImpl.java
@@ -340,12 +340,18 @@ public class EsUtilServiceImpl implements EsUtilService {
 
     private void addQueryStringToFilter(String searchString, BoolQuery.Builder boolQueryBuilder) {
         if (isNotBlank(searchString)) {
-            Query wildcardQuery = Query.of(q -> q.wildcard(
-                    WildcardQuery.of(w -> w
+            String lowerSearch = searchString.toLowerCase().trim();
+            boolQueryBuilder.must(Query.of(q -> q.bool(b -> b
+                    .should(Query.of(q1 -> q1.term(t -> t
                             .field("searchTags.keyword")
-                            .value("*" + searchString.toLowerCase() + "*"))
-            ));
-            boolQueryBuilder.must(wildcardQuery);
+                            .value(lowerSearch))))
+                    .should(Query.of(q2 -> q2.prefix(p -> p
+                            .field("searchTags.keyword")
+                            .value(lowerSearch))))
+                    .should(Query.of(q3 -> q3.wildcard(w -> w
+                            .field("searchTags.keyword")
+                            .value("*" + lowerSearch + "*"))))
+            )));
         }
     }
 


### PR DESCRIPTION
Exact matches should be prioritised at the top. 2. Prefix matches should come after exact matches. 3. The matches should follow both exact and prefix matches.