### PR TITLE
KB-12389: Designation search fix to support case-insensitive filtering

### DIFF
--- a/src/main/java/com/igot/cb/pores/elasticsearch/service/EsUtilServiceImpl.java
+++ b/src/main/java/com/igot/cb/pores/elasticsearch/service/EsUtilServiceImpl.java
@@ -340,12 +340,18 @@ public class EsUtilServiceImpl implements EsUtilService {
 
     private void addQueryStringToFilter(String searchString, BoolQuery.Builder boolQueryBuilder) {
         if (isNotBlank(searchString)) {
-            Query wildcardQuery = Query.of(q -> q.wildcard(
-                    WildcardQuery.of(w -> w
+            String lowerSearch = searchString.toLowerCase().trim();
+            boolQueryBuilder.must(Query.of(q -> q.bool(b -> b
+                    .should(Query.of(q1 -> q1.term(t -> t
                             .field("searchTags.keyword")
-                            .value("*" + searchString.toLowerCase() + "*"))
-            ));
-            boolQueryBuilder.must(wildcardQuery);
+                            .value(lowerSearch))))
+                    .should(Query.of(q2 -> q2.prefix(p -> p
+                            .field("searchTags.keyword")
+                            .value(lowerSearch))))
+                    .should(Query.of(q3 -> q3.wildcard(w -> w
+                            .field("searchTags.keyword")
+                            .value("*" + lowerSearch + "*"))))
+            )));
         }
     }
 

--- a/src/main/java/com/igot/cb/pores/util/Constants.java
+++ b/src/main/java/com/igot/cb/pores/util/Constants.java
@@ -268,7 +268,7 @@ public class Constants {
     public static final String UPDATED_DESIGNATION = "Updated Designations";
     public static final String DESIGNATION = "designation";
     public static final String DESCRIPTION_PAYLOAD = "Description";
-    public static final String DESIGNATION_INDEX_NAME = "designation_entity";
+    public static final String DESIGNATION_INDEX_NAME = "designation_entity_alias";
     public static final String TERM_CREATE_PAYLOAD_VALIDATION = "/payloadValidation/termCreateValidation.json";
     public static final String REF_ID = "refId";
     public static final String REF_TYPE = "refType";


### PR DESCRIPTION
KB-12389:Selected designation page is displaying empty

Description: Reindexing is required to add a normaliser in the ES index of designation_entity to support case-insensitive filtering of the designation on the "designation" attribute. Also, I added an alias, so in the future,e no need to do a code change to change the name of the index.

This is the supportive document
https://karmayogibharat.atlassian.net/wiki/spaces/TES/pages/705691657/Hot+Fix+Deployment+Guide