### PR TITLE
KB-13317 Once user make into active to inactive provider its taking 10m time to reflect

### DIFF
--- a/src/main/java/com/igot/cb/contentpartner/service/impl/ContentPartnerServiceImpl.java
+++ b/src/main/java/com/igot/cb/contentpartner/service/impl/ContentPartnerServiceImpl.java
@@ -129,6 +129,8 @@ public class ContentPartnerServiceImpl implements ContentPartnerService {
                         cacheService.deleteCache(newPartnerCode);
                     }
                     cacheService.deleteCache(updateJsonEntity.getId());
+                    // Clear search-related Redis cache
+                    clearSearchCache();
                 }
                 log.info(Constants.UPDATED_CONTENT_PARTNER);
                 response.setResult(result);
@@ -240,6 +242,8 @@ public class ContentPartnerServiceImpl implements ContentPartnerService {
         esUtilService.addDocument(Constants.CONTENT_PROVIDER_INDEX_NAME, Constants.INDEX_TYPE, id, map, cbServerProperties.getElasticContentJsonPath());
         Map<String, Object> result = objectMapper.convertValue(saveJsonEntity, Map.class);
         cacheService.putCache(saveJsonEntity.getId(), result);
+        // Clear search-related Redis cache
+        clearSearchCache();
         log.info(Constants.CONTENT_PARTNER_CREATED);
         response.setResult(result);
         response.setResponseCode(HttpStatus.OK);
@@ -385,6 +389,8 @@ public class ContentPartnerServiceImpl implements ContentPartnerService {
                     esUtilService.addDocument(Constants.CONTENT_PROVIDER_INDEX_NAME, Constants.INDEX_TYPE, id, map, cbServerProperties.getElasticContentJsonPath());
                     cacheService.deleteCache(id);
                     cacheService.deleteCache((String) map.get(Constants.PARTNERCODE));
+                    // Clear search-related Redis cache
+                    clearSearchCache();
                     Map<String,Object> map1=new HashMap<>();
                     map1.put(id,Constants.DELETED_SUCCESSFULLY);
                     response.setResponseCode(HttpStatus.OK);
@@ -451,6 +457,48 @@ public class ContentPartnerServiceImpl implements ContentPartnerService {
         return "";
     }
 
+    /**
+     * Clear search-related Redis cache entry for content partner search.
+     * Clears the specific search pattern used in the UI.
+     */
+    private void clearSearchCache() {
+        try {
+            String cacheKey = generateRedisJwtTokenKey(buildCommonSearchPatterns());
+            if (StringUtils.isNotBlank(cacheKey)) {
+                Boolean deleted = redisTemplate.delete(cacheKey);
+                if (Boolean.TRUE.equals(deleted)) {
+                    log.info("Cleared search cache entry from Redis after partner status change. Key: {}", cacheKey);
+                } else {
+                    log.debug("No search cache entry found to delete for key: {}", cacheKey);
+                }
+            }
+        } catch (Exception e) {
+            log.error("Error clearing search cache from Redis: {}", e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Build common search patterns that are typically used and need cache invalidation.
+     * IMPORTANT: Must include all fields (including nulls) to match exact JWT token.
+     */
+    private SearchCriteria buildCommonSearchPatterns() {
+        SearchCriteria searchCriteria = new SearchCriteria();
+        Map<String, Object> filterMap1 = new HashMap<>();
+        filterMap1.put(Constants.PROVIDER_TYPE, Collections.singletonList(Constants.EXTERNAL));
+        searchCriteria.setFilterCriteriaMap((HashMap<String, Object>) filterMap1);
+        searchCriteria.setRequestedFields(null);
+        searchCriteria.setPageNumber(0);
+        searchCriteria.setPageSize(20);
+        searchCriteria.setOrderBy(Constants.UPDATED_ON);
+        searchCriteria.setOrderDirection(Constants.DESC);
+        searchCriteria.setSearchString(null);
+        searchCriteria.setFacets(Collections.singletonList(Constants.CONTENT_PARTNER_NAME));
+        searchCriteria.setQuery(null);
+        searchCriteria.setStartsWith(null);
+        searchCriteria.setStartsWithField(null);
+        return searchCriteria;
+    }
+
     @Override
     public ApiResponse activate(JsonNode partnerDetails) {
         log.info("ContentPartnerServiceImpl::activate: activating the content partner");
@@ -479,6 +527,8 @@ public class ContentPartnerServiceImpl implements ContentPartnerService {
                 esUtilService.addDocument(Constants.CONTENT_PROVIDER_INDEX_NAME, Constants.INDEX_TYPE, id, map, cbServerProperties.getElasticContentJsonPath());
                 cacheService.deleteCache(id);
                 cacheService.deleteCache((String) map.get(Constants.PARTNERCODE));
+                // Clear search-related Redis cache
+                clearSearchCache();
                 Map<String, Object> result = new HashMap<>();
                 result.put(id, Constants.ACTIVATED_SUCCESSFULLY);
                 response.setResponseCode(HttpStatus.OK);

--- a/src/main/java/com/igot/cb/pores/util/Constants.java
+++ b/src/main/java/com/igot/cb/pores/util/Constants.java
@@ -450,7 +450,7 @@ public class Constants {
     public static final String LOG_ES_UPDATE_FAILURE = "ES update failed for contentId={}";
     public static final String LOG_DB_BULK_UPDATE_SUCCESS = "DB bulk update successful for receivedContentIdsSize={} and updatedRecordsCount={}";
     public static final String LOG_DB_BULK_UPDATE_FAILURE = "DB bulk update failed for contentIds={}";
-
+    public static final String DESC = "desc";
 
 
     private Constants() {

--- a/src/test/java/com/igot/cb/contentpartner/service/impl/ContentPartnerServiceImplTest.java
+++ b/src/test/java/com/igot/cb/contentpartner/service/impl/ContentPartnerServiceImplTest.java
@@ -765,4 +765,235 @@ class ContentPartnerServiceImplTest {
     }
 
 
+    // ========================= Cache Clearing Tests =========================
+
+    @Test
+    void testDelete_ShouldClearSearchCache() {
+        // Arrange
+        mockEntity = new ContentPartnerEntity();
+        mockEntity.setId("partner-123");
+        mockEntity.setIsActive(true);
+        mockEntity.setUpdatedOn(new Timestamp(System.currentTimeMillis()));
+
+        ObjectNode objectNode = realObjectMapper.createObjectNode();
+        objectNode.put(Constants.PARTNERCODE, "TEST123");
+        objectNode.put(Constants.IS_ACTIVE, true);
+        mockEntity.setData(objectNode);
+
+        when(entityRepository.findByIdAndIsActive("partner-123", true)).thenReturn(Optional.of(mockEntity));
+        when(objectMapper.convertValue(any(), eq(Map.class))).thenReturn(Map.of(Constants.PARTNERCODE, "TEST123"));
+        when(cbServerProperties.getElasticContentJsonPath()).thenReturn("path/to/schema");
+        when(cbServerProperties.getContentPartnerDeleteTopic()).thenReturn("delete-topic");
+        when(redisTemplate.delete(anyString())).thenReturn(true);
+
+        // Act
+        ApiResponse response = contentPartnerService.delete("partner-123");
+
+        // Assert
+        assertEquals(HttpStatus.OK, response.getResponseCode());
+
+        // Verify cache clearing was called
+        verify(redisTemplate, times(1)).delete(anyString());
+
+        // Verify entity was saved with isActive=false
+        ArgumentCaptor<ContentPartnerEntity> entityCaptor = ArgumentCaptor.forClass(ContentPartnerEntity.class);
+        verify(entityRepository).save(entityCaptor.capture());
+        assertFalse(entityCaptor.getValue().getIsActive());
+
+        // Verify ES was updated
+        verify(esUtilService).addDocument(eq(Constants.CONTENT_PROVIDER_INDEX_NAME), eq(Constants.INDEX_TYPE),
+                eq("partner-123"), anyMap(), anyString());
+    }
+
+    @Test
+    void testActivate_ShouldClearSearchCache() {
+        // Arrange
+        ObjectNode requestNode = realObjectMapper.createObjectNode();
+        requestNode.put(Constants.PARTNER_ID, "partner-456");
+
+        mockEntity = new ContentPartnerEntity();
+        mockEntity.setId("partner-456");
+        mockEntity.setIsActive(false);
+
+        ObjectNode dataNode = realObjectMapper.createObjectNode();
+        dataNode.put(Constants.PARTNERCODE, "ACTIVE123");
+        dataNode.put(Constants.IS_ACTIVE, false);
+        mockEntity.setData(dataNode);
+
+        when(entityRepository.findByIdAndIsActive("partner-456", false)).thenReturn(Optional.of(mockEntity));
+        when(objectMapper.convertValue(any(), eq(Map.class))).thenReturn(Map.of(Constants.PARTNERCODE, "ACTIVE123"));
+        when(cbServerProperties.getElasticContentJsonPath()).thenReturn("path/to/schema");
+        when(cbServerProperties.getContentPartnerActivateTopic()).thenReturn("activate-topic");
+        when(redisTemplate.delete(anyString())).thenReturn(true);
+
+        // Act
+        ApiResponse response = contentPartnerService.activate(requestNode);
+
+        // Assert
+        assertEquals(HttpStatus.OK, response.getResponseCode());
+
+        // Verify cache clearing was called
+        verify(redisTemplate, times(1)).delete(anyString());
+
+        // Verify entity was saved with isActive=true
+        ArgumentCaptor<ContentPartnerEntity> entityCaptor = ArgumentCaptor.forClass(ContentPartnerEntity.class);
+        verify(entityRepository).save(entityCaptor.capture());
+        assertTrue(entityCaptor.getValue().getIsActive());
+
+        // Verify Kafka event was published
+        verify(kafkaProducer).push(eq("activate-topic"), anyMap());
+    }
+
+    @Test
+    void testActivate_WithNullPartnerId_ShouldReturnBadRequest() {
+        // Arrange
+        ObjectNode requestNode = realObjectMapper.createObjectNode();
+        // partnerId is null
+
+        // Act
+        ApiResponse response = contentPartnerService.activate(requestNode);
+
+        // Assert
+        assertEquals(HttpStatus.BAD_REQUEST, response.getResponseCode());
+        assertEquals(Constants.INVALID_ID, response.getParams().getErrMsg());
+
+        // Verify no cache clearing was attempted
+        verify(redisTemplate, never()).delete(anyString());
+    }
+
+    @Test
+    void testActivate_PartnerNotFound_ShouldReturnBadRequest() {
+        // Arrange
+        ObjectNode requestNode = realObjectMapper.createObjectNode();
+        requestNode.put(Constants.PARTNER_ID, "non-existent");
+
+        when(entityRepository.findByIdAndIsActive("non-existent", false)).thenReturn(Optional.empty());
+
+        // Act
+        ApiResponse response = contentPartnerService.activate(requestNode);
+
+        // Assert
+        assertEquals(HttpStatus.BAD_REQUEST, response.getResponseCode());
+        assertEquals(Constants.CONTENT_PARTNER_NOT_FOUND, response.getParams().getErrMsg());
+
+        // Verify no cache clearing was attempted
+        verify(redisTemplate, never()).delete(anyString());
+    }
+
+    @Test
+    void testDelete_CacheKeyGeneration_MatchesSearchPattern() {
+        // Arrange
+        mockEntity = new ContentPartnerEntity();
+        mockEntity.setId("test-id");
+        mockEntity.setIsActive(true);
+
+        ObjectNode dataNode = realObjectMapper.createObjectNode();
+        dataNode.put(Constants.PARTNERCODE, "TEST");
+        mockEntity.setData(dataNode);
+
+        when(entityRepository.findByIdAndIsActive("test-id", true)).thenReturn(Optional.of(mockEntity));
+        when(objectMapper.convertValue(any(), eq(Map.class))).thenReturn(Map.of(Constants.PARTNERCODE, "TEST"));
+        when(cbServerProperties.getElasticContentJsonPath()).thenReturn("path");
+        when(cbServerProperties.getContentPartnerDeleteTopic()).thenReturn("topic");
+        when(redisTemplate.delete(anyString())).thenReturn(true);
+
+        // Act
+        contentPartnerService.delete("test-id");
+
+        // Assert - Verify the cache key was generated and deleted
+        ArgumentCaptor<String> cacheKeyCaptor = ArgumentCaptor.forClass(String.class);
+        verify(redisTemplate).delete(cacheKeyCaptor.capture());
+
+        String cacheKey = cacheKeyCaptor.getValue();
+        assertNotNull(cacheKey);
+        assertFalse(cacheKey.isEmpty());
+
+        // The cache key should be a JWT token (starts with eyJ)
+        assertTrue(cacheKey.startsWith("eyJ"), "Cache key should be a JWT token");
+    }
+
+    @Test
+    void testDelete_CacheClearingException_ShouldNotFailOperation() {
+        // Arrange
+        mockEntity = new ContentPartnerEntity();
+        mockEntity.setId("partner-789");
+        mockEntity.setIsActive(true);
+
+        ObjectNode dataNode = realObjectMapper.createObjectNode();
+        dataNode.put(Constants.PARTNERCODE, "FAIL123");
+        mockEntity.setData(dataNode);
+
+        when(entityRepository.findByIdAndIsActive("partner-789", true)).thenReturn(Optional.of(mockEntity));
+        when(objectMapper.convertValue(any(), eq(Map.class))).thenReturn(Map.of(Constants.PARTNERCODE, "FAIL123"));
+        when(cbServerProperties.getElasticContentJsonPath()).thenReturn("path");
+        when(cbServerProperties.getContentPartnerDeleteTopic()).thenReturn("topic");
+        when(redisTemplate.delete(anyString())).thenThrow(new RuntimeException("Redis connection failed"));
+
+        // Act
+        ApiResponse response = contentPartnerService.delete("partner-789");
+
+        // Assert - Operation should still succeed even if cache clearing fails
+        assertEquals(HttpStatus.OK, response.getResponseCode());
+
+        // Verify entity was still saved
+        verify(entityRepository).save(any(ContentPartnerEntity.class));
+        verify(esUtilService).addDocument(anyString(), anyString(), anyString(), anyMap(), anyString());
+    }
+
+    @Test
+    void testActivate_CacheClearingSuccess_ShouldLogCorrectly() {
+        // Arrange
+        ObjectNode requestNode = realObjectMapper.createObjectNode();
+        requestNode.put(Constants.PARTNER_ID, "partner-log-test");
+
+        mockEntity = new ContentPartnerEntity();
+        mockEntity.setId("partner-log-test");
+        mockEntity.setIsActive(false);
+
+        ObjectNode dataNode = realObjectMapper.createObjectNode();
+        dataNode.put(Constants.PARTNERCODE, "LOG123");
+        mockEntity.setData(dataNode);
+
+        when(entityRepository.findByIdAndIsActive("partner-log-test", false)).thenReturn(Optional.of(mockEntity));
+        when(objectMapper.convertValue(any(), eq(Map.class))).thenReturn(Map.of(Constants.PARTNERCODE, "LOG123"));
+        when(cbServerProperties.getElasticContentJsonPath()).thenReturn("path");
+        when(cbServerProperties.getContentPartnerActivateTopic()).thenReturn("topic");
+        when(redisTemplate.delete(anyString())).thenReturn(true); // Successfully deleted
+
+        // Act
+        ApiResponse response = contentPartnerService.activate(requestNode);
+
+        // Assert
+        assertEquals(HttpStatus.OK, response.getResponseCode());
+        verify(redisTemplate).delete(anyString());
+    }
+
+    @Test
+    void testActivate_NoCacheEntryToDelete_ShouldStillSucceed() {
+        // Arrange
+        ObjectNode requestNode = realObjectMapper.createObjectNode();
+        requestNode.put(Constants.PARTNER_ID, "partner-no-cache");
+
+        mockEntity = new ContentPartnerEntity();
+        mockEntity.setId("partner-no-cache");
+        mockEntity.setIsActive(false);
+
+        ObjectNode dataNode = realObjectMapper.createObjectNode();
+        dataNode.put(Constants.PARTNERCODE, "NOCACHE");
+        mockEntity.setData(dataNode);
+
+        when(entityRepository.findByIdAndIsActive("partner-no-cache", false)).thenReturn(Optional.of(mockEntity));
+        when(objectMapper.convertValue(any(), eq(Map.class))).thenReturn(Map.of(Constants.PARTNERCODE, "NOCACHE"));
+        when(cbServerProperties.getElasticContentJsonPath()).thenReturn("path");
+        when(cbServerProperties.getContentPartnerActivateTopic()).thenReturn("topic");
+        when(redisTemplate.delete(anyString())).thenReturn(false); // No cache entry found
+
+        // Act
+        ApiResponse response = contentPartnerService.activate(requestNode);
+
+        // Assert
+        assertEquals(HttpStatus.OK, response.getResponseCode());
+        verify(redisTemplate).delete(anyString());
+    }
 }
+


### PR DESCRIPTION
Fix: Once partner details updated default search payload cache removed.