### PR TITLE
Cbrelease 4.8.34 (#220)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,7 @@
 FROM openjdk:17.0.1-jdk-slim
+
+RUN useradd -ms /bin/bash appuser
+
 # Install necessary dependencies
 RUN apt-get update \
     && apt-get install -y \
@@ -12,6 +15,11 @@ RUN apt-get update \
         xz-utils \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
+
 COPY cb-pores-service-0.0.1-SNAPSHOT.jar /opt/
+RUN chown -R appuser:appuser /opt
+USER appuser
+WORKDIR /opt
+
 #HEALTHCHECK --interval=30s --timeout=30s CMD curl --fail http://localhost:7001/actuator/health || exit 1
 CMD ["/bin/bash", "-c", "java -XX:+PrintFlagsFinal $JAVA_OPTIONS -XX:+UnlockExperimentalVMOptions -jar /opt/cb-pores-service-0.0.1-SNAPSHOT.jar"]


### PR DESCRIPTION
* Add user and change ownership in Dockerfile

* KB-13317 Once user make into active to inactive provider its taking 10m time to reflect
1. Fix: Once partner details updated default search payload cache removed.

* KB-13317 Once user make into active to inactive provider its taking 10m time to reflect
1. Fix: Once partner details updated default search payload cache removed.

* KB-13626 : added new role to framework read

---------