### PR TITLE
KBN-12543 (Igot ES load Issue)

### DIFF
--- a/src/main/java/com/igot/cb/designation/service/impl/DesignationServiceImpl.java
+++ b/src/main/java/com/igot/cb/designation/service/impl/DesignationServiceImpl.java
@@ -595,10 +595,10 @@ public class DesignationServiceImpl implements DesignationService {
       }
     try {
       if (searchCriteria.getStartsWith() != null && StringUtils.isNotBlank(searchCriteria.getStartsWith())) {
-        searchCriteria.setStartsWithField(Constants.DESIGNATION);
+        searchCriteria.setStartsWithField(Constants.DESIGNATION+Constants.KEYWORD);
       }
       searchResult =
-          esUtilService.searchDocuments(Constants.DESIGNATION_INDEX_NAME, searchCriteria);
+          esUtilService.searchDocumentsV2(Constants.DESIGNATION_INDEX_NAME, searchCriteria);
       response.getResult().put(Constants.RESULT, searchResult);
       createSuccessResponse(response);
       return response;

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -144,6 +144,6 @@ search.criteria.default.facets=channel
 search.criteria.default.requested.fields=name,description,createdOn,updatedOn,category,announcementId
 content.partner.search.page-size=500
 
-search.fields.with.boost=title:5.0,tags:3.0,summary:2.0
+search.fields.with.boost=title:5.0,tags:3.0,summary:2.0,searchTags:5.0
 
 partner.code.characters=


### PR DESCRIPTION
RCA: Leading-wildcard queries (*term*) on searchTags for every keystroke forced full term-dictionary scans on every request, saturating ES node CPU (~99–100%) and causing 30s search timeouts.
Fix: Reindex searchTags with an ngram analyzer and replace the wildcard query with a standard match query to eliminate the dictionary scan.

Now updated for Designation elastic search reindex and Search.

Designation search wild card search query removed and updated with match query.