### PR TITLE
KB-15117 add configurable validation for designation creation

### DIFF
--- a/src/main/java/com/igot/cb/designation/service/impl/DesignationServiceImpl.java
+++ b/src/main/java/com/igot/cb/designation/service/impl/DesignationServiceImpl.java
@@ -462,6 +462,7 @@ public class DesignationServiceImpl implements DesignationService {
     String designation = designationDetails.get(Constants.DESIGNATION).asText();
     if (designation.isBlank()
         || !designation.matches(cbServerProperties.getDesignationValidationRegex())) {
+      response.setMessage(Constants.INVALID_DESIGNATION);
       response.setResponseCode(HttpStatus.BAD_REQUEST);
       return response;
     }

--- a/src/main/java/com/igot/cb/designation/service/impl/DesignationServiceImpl.java
+++ b/src/main/java/com/igot/cb/designation/service/impl/DesignationServiceImpl.java
@@ -462,7 +462,7 @@ public class DesignationServiceImpl implements DesignationService {
     String designation = designationDetails.get(Constants.DESIGNATION).asText();
     if (designation.isBlank()
         || !designation.matches(cbServerProperties.getDesignationValidationRegex())) {
-      response.setMessage(Constants.INVALID_DESIGNATION);
+      response.getParams().setErrmsg(Constants.INVALID_DESIGNATION);
       response.setResponseCode(HttpStatus.BAD_REQUEST);
       return response;
     }

--- a/src/main/java/com/igot/cb/designation/service/impl/DesignationServiceImpl.java
+++ b/src/main/java/com/igot/cb/designation/service/impl/DesignationServiceImpl.java
@@ -459,6 +459,12 @@ public class DesignationServiceImpl implements DesignationService {
     log.info("DesignationServiceImpl::createDesignation");
     payloadValidation.validatePayload(Constants.DESIGNATION_PAYLOAD_VALIDATION,designationDetails);
     CustomResponse response = new CustomResponse();
+    String designation = designationDetails.get(Constants.DESIGNATION).asText();
+    if (designation.isBlank()
+        || !designation.matches(cbServerProperties.getDesignationValidationRegex())) {
+      response.setResponseCode(HttpStatus.BAD_REQUEST);
+      return response;
+    }
     SearchCriteria searchCriteria = new SearchCriteria();
     searchCriteria.setPageNumber(0);
     searchCriteria.setPageSize(5000);

--- a/src/main/java/com/igot/cb/pores/util/CbServerProperties.java
+++ b/src/main/java/com/igot/cb/pores/util/CbServerProperties.java
@@ -122,6 +122,9 @@ public class CbServerProperties {
   @Value("${elastic.required.field.designation.json.path}")
   private String elasticDesignationJsonPath;
 
+  @Value("${designation.validation.regex}")
+  private String designationValidationRegex;
+
   @Value("${odcs.framework.name}")
   private String odcsDesignationFramework;
 

--- a/src/main/java/com/igot/cb/pores/util/Constants.java
+++ b/src/main/java/com/igot/cb/pores/util/Constants.java
@@ -76,6 +76,9 @@ public class Constants {
     public static final String SUCCESSFULLY_READING = "successfully read";
     public static final String ID_NOT_FOUND = "Id not found";
     public static final String INVALID_ID = "Invalid Id";
+    public static final String INVALID_DESIGNATION =
+            "Designation cannot be blank and may contain only letters, numbers, spaces, "
+                    + "and these special characters: ( ) & / , + -";
     public static final String DELETED_SUCCESSFULLY = "deleted successfully";
     public static final String ALREADY_INACTIVE = "already inactive Id";
     public static final String ERROR_WHILE_DELETING_DEMAND = "Error while deleting demand with ID";

--- a/src/main/java/com/igot/cb/pores/util/Constants.java
+++ b/src/main/java/com/igot/cb/pores/util/Constants.java
@@ -77,8 +77,7 @@ public class Constants {
     public static final String ID_NOT_FOUND = "Id not found";
     public static final String INVALID_ID = "Invalid Id";
     public static final String INVALID_DESIGNATION =
-            "Designation cannot be blank and may contain only letters, numbers, spaces, "
-                    + "and these special characters: ( ) & / , + -";
+            "Invalid designation. It cannot be blank and must contain only valid characters.";
     public static final String DELETED_SUCCESSFULLY = "deleted successfully";
     public static final String ALREADY_INACTIVE = "already inactive Id";
     public static final String ERROR_WHILE_DELETING_DEMAND = "Error while deleting demand with ID";

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -108,6 +108,7 @@ sb.search.service.host=http://search-service:9000
 sb.composite.v4.search=/v4/search
 playlist_course_facets=courseCategory,primaryCategory
 elastic.required.field.designation.json.path=/EsFieldsmapping/designationEsRequiredFile.json
+designation.validation.regex=^[a-zA-Z0-9 ()&/,+-]*$
 
 knowledge.mv.service=http://knowledge-mw-service:5000/
 odcs.term.create=v1/framework/term/create

--- a/src/test/java/com/igot/cb/designation/service/impl/DesignationServiceImplTest.java
+++ b/src/test/java/com/igot/cb/designation/service/impl/DesignationServiceImplTest.java
@@ -111,6 +111,8 @@ class DesignationServiceImplTest {
     @BeforeEach
     void setUp() {
         MockitoAnnotations.initMocks(this);
+        when(cbServerProperties.getDesignationValidationRegex())
+                .thenReturn("^[a-zA-Z0-9 ()&/,+-]*$");
     }
 
     /**
@@ -133,6 +135,7 @@ class DesignationServiceImplTest {
         when(esUtilService.isIndexPresent(Constants.DESIGNATION_INDEX_NAME)).thenReturn(true);
         when(esUtilService.searchDocuments(any(), any())).thenReturn(searchResult);
         when(dataNode.isEmpty()).thenReturn(false);
+        when(designationDetails.get(Constants.DESIGNATION)).thenReturn(TextNode.valueOf("Principal"));
 
         // Act
         CustomResponse response = designationService.createDesignation(designationDetails);
@@ -1194,7 +1197,7 @@ class DesignationServiceImplTest {
         // Create input designationDetails JSON
         ObjectMapper realObjectMapper = new ObjectMapper();
         ObjectNode designationDetails = realObjectMapper.createObjectNode();
-        designationDetails.put(Constants.DESIGNATION, "Principal");
+        designationDetails.put(Constants.DESIGNATION, "Director & Head (Grade-1)/Admin,+");
 
         // Mock payload validation
         doNothing().when(payloadValidation)
@@ -1233,6 +1236,30 @@ class DesignationServiceImplTest {
         assertEquals(HttpStatus.OK, response.getResponseCode());
         assertEquals(Constants.SUCCESSFULLY_CREATED, response.getMessage());
         assertTrue(((Map<?, ?>) response.getResult()).containsKey(Constants.ID));
+    }
+
+    @Test
+    void testCreateDesignation_rejectsUnsupportedCharactersBeforeDataAccess() {
+        ObjectNode designationDetails = new ObjectMapper().createObjectNode();
+        designationDetails.put(Constants.DESIGNATION, "Manager @ HQ");
+
+        CustomResponse response = designationService.createDesignation(designationDetails);
+
+        assertEquals(HttpStatus.BAD_REQUEST, response.getResponseCode());
+        verifyNoInteractions(esUtilService, designationRepository, cacheService);
+    }
+
+    @Test
+    void testCreateDesignation_rejectsEmptyAndBlankDesignationBeforeDataAccess() {
+        for (String invalidDesignation : List.of("", "   ")) {
+            ObjectNode designationDetails = new ObjectMapper().createObjectNode();
+            designationDetails.put(Constants.DESIGNATION, invalidDesignation);
+
+            CustomResponse response = designationService.createDesignation(designationDetails);
+
+            assertEquals(HttpStatus.BAD_REQUEST, response.getResponseCode());
+        }
+        verifyNoInteractions(esUtilService, designationRepository, cacheService);
     }
 
     @Test


### PR DESCRIPTION
## Summary
Added create-specific validation for designation names in `POST /designation/create`.

## Changes
- Added configurable regex:
  `^[a-zA-Z0-9 ()&/,+-]*$`
- Rejects empty, whitespace-only, and regex-invalid designation values with HTTP 400.
- Performs validation before Elasticsearch duplicate lookup and PostgreSQL/Redis operations.
- Kept the existing shared designation validation schema unchanged.
- No custom error message added because designation creation is backend-only.
- Existing update, bulk upload, internal, read, and search flows remain unaffected.
